### PR TITLE
Implement fallback flow for magnetic-scroll on short viewports

### DIFF
--- a/docs/superpowers/plans/2026-06-30-short-viewport-flow-fallback.md
+++ b/docs/superpowers/plans/2026-06-30-short-viewport-flow-fallback.md
@@ -1,0 +1,498 @@
+# Short-Viewport Flow Fallback — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** When a magnetic-scroll section's tallest card can't fit in the viewport (e.g. 1080p at Windows 150% scaling), fall back to the existing flow (native-scroll) layout so content is never clipped — and switch back when the viewport grows again.
+
+**Architecture:** Add a `tooTall` signal next to the existing `isMobile` signal; a `useFlow = isMobile || tooTall` computed drives the template `@if`. `tooTall` is set by measuring the tallest card against the stage height. Listener wiring (desktop wheel/touch vs flow native scroll) moves from a one-shot `ngAfterViewInit` call to an idempotent `syncLayout()` driven by an `effect` on `useFlow`. A window `resize` handler re-evaluates the fit in both directions.
+
+**Tech Stack:** Angular 21 (standalone, signals, `effect`/`computed`), Karma + Jasmine.
+
+**Spec:** `docs/superpowers/specs/2026-06-30-short-viewport-flow-fallback-design.md`
+
+---
+
+## File Structure
+
+- **Modify** `src/app/shared/magnetic-scroll/magnetic-scroll.component.ts` — add the decision function, the `tooTall`/`useFlow` signals, the reactive `syncLayout()` wiring, and the resize handler.
+- **Modify** `src/app/shared/magnetic-scroll/magnetic-scroll.component.html` — switch the layout `@if` from `isMobile()` to `useFlow()`.
+- **Create** `src/app/shared/magnetic-scroll/magnetic-scroll.component.spec.ts` — unit-test the pure decision function.
+
+The whole change is contained in one component. No new files of consequence beyond the spec.
+
+---
+
+## Task 1: Pure fit-decision function + unit test
+
+Extract the "does the tallest card overflow the stage?" rule as a pure static method so it can be tested without the DOM.
+
+**Files:**
+- Modify: `src/app/shared/magnetic-scroll/magnetic-scroll.component.ts`
+- Create: `src/app/shared/magnetic-scroll/magnetic-scroll.component.spec.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/app/shared/magnetic-scroll/magnetic-scroll.component.spec.ts`:
+
+```ts
+import { MagneticScrollComponent } from './magnetic-scroll.component';
+
+describe('MagneticScrollComponent.exceedsStage', () => {
+  it('returns false when the tallest card fits within the stage minus safety', () => {
+    expect(MagneticScrollComponent.exceedsStage(600, 720, 24)).toBe(false);
+  });
+
+  it('returns true when the tallest card exceeds the stage minus safety', () => {
+    expect(MagneticScrollComponent.exceedsStage(710, 720, 24)).toBe(true);
+  });
+
+  it('counts the safety margin as part of the budget', () => {
+    // 700 fits in 720 raw, but not in 720 - 24 = 696
+    expect(MagneticScrollComponent.exceedsStage(700, 720, 24)).toBe(true);
+  });
+
+  it('returns false for a non-positive stage height (not yet measured)', () => {
+    expect(MagneticScrollComponent.exceedsStage(700, 0, 24)).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npm test -- --watch=false --browsers=ChromeHeadless`
+Expected: compile/build FAIL — `Property 'exceedsStage' does not exist on type 'typeof MagneticScrollComponent'`.
+
+- [ ] **Step 3: Add the static method**
+
+In `src/app/shared/magnetic-scroll/magnetic-scroll.component.ts`, add this method inside the `MagneticScrollComponent` class (e.g. just after the class opening, before the `@Input`):
+
+```ts
+  /**
+   * True when the tallest card overflows the stage. `safety` reserves a little
+   * breathing room so cards are never flush against the stage edges.
+   * Returns false when the stage hasn't been measured yet (height <= 0).
+   */
+  static exceedsStage(
+    maxCardHeight: number,
+    stageHeight: number,
+    safety: number,
+  ): boolean {
+    if (stageHeight <= 0) return false;
+    return maxCardHeight > stageHeight - safety;
+  }
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `npm test -- --watch=false --browsers=ChromeHeadless`
+Expected: PASS — 4 specs in the `exceedsStage` describe block green (the rest of the suite also runs and should stay green).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/app/shared/magnetic-scroll/magnetic-scroll.component.spec.ts src/app/shared/magnetic-scroll/magnetic-scroll.component.ts
+git commit -m "feat(magnetic-scroll): add pure card-fit decision function"
+```
+
+---
+
+## Task 2: Add `tooTall` / `useFlow` signals and switch the template
+
+Introduce the new state. `tooTall` stays `false` for now, so behaviour is unchanged — this task is purely additive and must leave the app working.
+
+**Files:**
+- Modify: `src/app/shared/magnetic-scroll/magnetic-scroll.component.ts`
+- Modify: `src/app/shared/magnetic-scroll/magnetic-scroll.component.html`
+
+- [ ] **Step 1: Import `computed`**
+
+In the `@angular/core` import block at the top of the `.ts`, add `computed` to the named imports. The block currently is:
+
+```ts
+import {
+  AfterViewInit,
+  Component,
+  ElementRef,
+  inject,
+  Input,
+  NgZone,
+  OnChanges,
+  OnDestroy,
+  QueryList,
+  signal,
+  SimpleChanges,
+  ViewChild,
+  ViewChildren,
+} from '@angular/core';
+```
+
+Change it to also include `computed` and `effect` (effect is used in Task 3, add both now):
+
+```ts
+import {
+  AfterViewInit,
+  Component,
+  computed,
+  effect,
+  ElementRef,
+  inject,
+  Input,
+  NgZone,
+  OnChanges,
+  OnDestroy,
+  QueryList,
+  signal,
+  SimpleChanges,
+  ViewChild,
+  ViewChildren,
+} from '@angular/core';
+```
+
+- [ ] **Step 2: Add the signals**
+
+Find the existing `isMobile` signal:
+
+```ts
+  readonly isMobile = signal(
+    typeof window !== 'undefined'
+      ? window.matchMedia('(max-width: 768px)').matches
+      : false,
+  );
+```
+
+Immediately after it, add:
+
+```ts
+  // True when the tallest card can't fit the stage → fall back to flow layout.
+  readonly tooTall = signal(false);
+
+  // The active layout: flow (native scroll) when narrow OR too tall, else cards.
+  readonly useFlow = computed(() => this.isMobile() || this.tooTall());
+```
+
+- [ ] **Step 3: Switch the template `@if`**
+
+In `src/app/shared/magnetic-scroll/magnetic-scroll.component.html`, change line 3 from:
+
+```html
+@if (isMobile()) {
+```
+
+to:
+
+```html
+@if (useFlow()) {
+```
+
+(The `@else` desktop branch and everything else stays untouched.)
+
+- [ ] **Step 4: Verify the app still builds**
+
+Run: `npm run build`
+Expected: build succeeds. Behaviour is unchanged because `tooTall` is always `false` so `useFlow() === isMobile()`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/app/shared/magnetic-scroll/magnetic-scroll.component.ts src/app/shared/magnetic-scroll/magnetic-scroll.component.html
+git commit -m "feat(magnetic-scroll): add useFlow state driving the layout switch"
+```
+
+---
+
+## Task 3: Reactive listener wiring + measurement-driven `tooTall`
+
+Replace the one-shot listener setup with an idempotent `syncLayout()` driven by an `effect` on `useFlow()`. Desktop measurement now sets `tooTall`. This is the core of the fix and the only structural change.
+
+**Files:**
+- Modify: `src/app/shared/magnetic-scroll/magnetic-scroll.component.ts`
+
+- [ ] **Step 1: Add fields for the fit cache and layout wiring**
+
+Find the existing private fields block:
+
+```ts
+  private heights: number[] = [];
+  private raf: number | null = null;
+  private snapTimer: ReturnType<typeof setTimeout> | null = null;
+  private wheelBusy = false;
+  private touchStart: { y: number; progress: number } | null = null;
+  private cleanups: (() => void)[] = [];
+
+  private ngZone = inject(NgZone);
+  private viewReady = false;
+```
+
+Replace it with (adds `FIT_SAFETY`, the fit cache, `wiredMode`, `layoutCleanups`, and the `effect`):
+
+```ts
+  private readonly FIT_SAFETY = 24;
+
+  private heights: number[] = [];
+  private maxCardHeight = 0;
+  private lastStageHeight = 0;
+  private lastInnerHeight = 0;
+  private raf: number | null = null;
+  private snapTimer: ReturnType<typeof setTimeout> | null = null;
+  private wheelBusy = false;
+  private touchStart: { y: number; progress: number } | null = null;
+  private cleanups: (() => void)[] = [];
+  private layoutCleanups: (() => void)[] = [];
+  private wiredMode: 'desktop' | 'flow' | null = null;
+
+  private ngZone = inject(NgZone);
+  private viewReady = false;
+
+  // Re-wires listeners and (re)measures whenever the active layout changes.
+  private readonly layoutEffect = effect(() => this.syncLayout());
+```
+
+- [ ] **Step 2: Simplify `ngAfterViewInit`**
+
+Replace the whole existing `ngAfterViewInit` (which directly attached desktop events and called `scheduleMeasureAndRender`) with this — wiring is now owned by the effect; this method only flattens and registers the global width listener:
+
+```ts
+  ngAfterViewInit(): void {
+    this.viewReady = true;
+    this.flatten();
+
+    if (typeof window !== 'undefined') {
+      const mq = window.matchMedia('(max-width: 768px)');
+      const onMqChange = (e: MediaQueryListEvent) => {
+        this.ngZone.run(() => this.isMobile.set(e.matches));
+      };
+      mq.addEventListener('change', onMqChange);
+      this.cleanups.push(() => mq.removeEventListener('change', onMqChange));
+    }
+  }
+```
+
+(The window `resize` listener is added in Task 4.)
+
+- [ ] **Step 3: Update `ngOnChanges` to go through `syncLayout`**
+
+Replace the existing `ngOnChanges`:
+
+```ts
+  ngOnChanges(changes: SimpleChanges): void {
+    if (!changes['sections']) return;
+    this.flatten();
+    if (!this.viewReady) return;
+    this.syncLayout();
+  }
+```
+
+- [ ] **Step 4: Tear down layout listeners on destroy**
+
+Replace the existing `ngOnDestroy`:
+
+```ts
+  ngOnDestroy(): void {
+    if (this.raf) cancelAnimationFrame(this.raf);
+    if (this.snapTimer) clearTimeout(this.snapTimer);
+    this.teardownLayoutListeners();
+    this.cleanups.forEach((fn) => fn());
+  }
+```
+
+- [ ] **Step 5: Replace `scheduleMeasureAndRender` with `syncLayout` + `measureAndDecide` + `teardownLayoutListeners`**
+
+Find and delete the existing `scheduleMeasureAndRender` method:
+
+```ts
+  private scheduleMeasureAndRender(): void {
+    this.scheduleDoubleRaf(() => {
+      if (!this.stageRef || this.flatItems.length === 0) return;
+      this.measureAllHeights();
+      const max = Math.max(0, this.flatItems.length - 1);
+      this.progress = Math.max(0, Math.min(max, this.progress));
+      this.render(this.progress);
+    });
+  }
+```
+
+In its place, add these three methods:
+
+```ts
+  // Wire the listeners for the active layout (idempotent) and, on desktop,
+  // (re)measure to decide whether the section still fits. Deferred a double-RAF
+  // so the @if has swapped the DOM and ViewChildren have updated.
+  private syncLayout(): void {
+    const target: 'desktop' | 'flow' = this.useFlow() ? 'flow' : 'desktop';
+    this.scheduleDoubleRaf(() => {
+      if (!this.viewReady) return;
+
+      if (this.wiredMode !== target) {
+        this.teardownLayoutListeners();
+        this.wiredMode = target;
+        if (target === 'desktop') {
+          this.attachEvents();
+        }
+        // flow: native scroll only — parity with existing mobile behaviour.
+      }
+
+      if (target === 'desktop') {
+        this.measureAndDecide();
+      }
+    });
+  }
+
+  // Measure the cards, cache the fit inputs, and flip `tooTall` accordingly.
+  private measureAndDecide(): void {
+    if (!this.stageRef || this.flatItems.length === 0) return;
+    this.measureAllHeights();
+    this.maxCardHeight = this.heights.length ? Math.max(...this.heights) : 0;
+    const stageH = this.stageRef.nativeElement.clientHeight;
+    this.lastStageHeight = stageH;
+    this.lastInnerHeight =
+      typeof window !== 'undefined' ? window.innerHeight : 0;
+    this.tooTall.set(
+      MagneticScrollComponent.exceedsStage(
+        this.maxCardHeight,
+        stageH,
+        this.FIT_SAFETY,
+      ),
+    );
+    const max = Math.max(0, this.flatItems.length - 1);
+    this.progress = Math.max(0, Math.min(max, this.progress));
+    this.render(this.progress);
+  }
+
+  private teardownLayoutListeners(): void {
+    this.layoutCleanups.forEach((fn) => fn());
+    this.layoutCleanups = [];
+  }
+```
+
+- [ ] **Step 6: Point `attachEvents` cleanups at `layoutCleanups`**
+
+In `attachEvents`, find the final `this.cleanups.push(` call that registers the wheel/touch removers:
+
+```ts
+      this.cleanups.push(
+        () => el.removeEventListener('wheel', onWheel),
+        () => el.removeEventListener('touchstart', onTouchStart),
+        () => el.removeEventListener('touchmove', onTouchMove),
+        () => el.removeEventListener('touchend', onTouchEnd),
+      );
+```
+
+Change `this.cleanups.push(` to `this.layoutCleanups.push(` (so these are torn down on every layout switch, not just on destroy):
+
+```ts
+      this.layoutCleanups.push(
+        () => el.removeEventListener('wheel', onWheel),
+        () => el.removeEventListener('touchstart', onTouchStart),
+        () => el.removeEventListener('touchmove', onTouchMove),
+        () => el.removeEventListener('touchend', onTouchEnd),
+      );
+```
+
+- [ ] **Step 7: Verify the build and the full test suite**
+
+Run: `npm run build`
+Expected: build succeeds.
+
+Run: `npm test -- --watch=false --browsers=ChromeHeadless`
+Expected: PASS — `exceedsStage` specs still green, existing suite green.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/app/shared/magnetic-scroll/magnetic-scroll.component.ts
+git commit -m "feat(magnetic-scroll): fall back to flow layout when cards overflow the stage"
+```
+
+---
+
+## Task 4: Resize round-trip (switch back when the viewport grows)
+
+Add a `resize` handler so the section returns to card layout when the window gets tall enough again — keeping height behaviour symmetric with the existing width behaviour.
+
+**Files:**
+- Modify: `src/app/shared/magnetic-scroll/magnetic-scroll.component.ts`
+
+- [ ] **Step 1: Register the resize listener in `ngAfterViewInit`**
+
+In `ngAfterViewInit`, inside the existing `if (typeof window !== 'undefined') { ... }` block, after the `mq` listener registration, add:
+
+```ts
+      const onResize = () => this.ngZone.run(() => this.onViewportResize());
+      window.addEventListener('resize', onResize);
+      this.cleanups.push(() => window.removeEventListener('resize', onResize));
+```
+
+- [ ] **Step 2: Add `onViewportResize`**
+
+Add this method next to `measureAndDecide`:
+
+```ts
+  // On resize: when cards are mounted, re-measure directly. When already in flow
+  // because of height, the chrome above the stage is fixed-px, so the stage
+  // height tracks innerHeight 1:1 — derive it from the cached measurement and
+  // re-decide without needing the (unmounted) desktop DOM.
+  private onViewportResize(): void {
+    if (this.isMobile()) return; // width transitions handled by matchMedia
+    if (this.wiredMode === 'desktop') {
+      this.measureAndDecide();
+    } else {
+      const stageH =
+        this.lastStageHeight + (window.innerHeight - this.lastInnerHeight);
+      this.tooTall.set(
+        MagneticScrollComponent.exceedsStage(
+          this.maxCardHeight,
+          stageH,
+          this.FIT_SAFETY,
+        ),
+      );
+    }
+  }
+```
+
+- [ ] **Step 3: Verify the build and tests**
+
+Run: `npm run build`
+Expected: build succeeds.
+
+Run: `npm test -- --watch=false --browsers=ChromeHeadless`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/app/shared/magnetic-scroll/magnetic-scroll.component.ts
+git commit -m "feat(magnetic-scroll): re-evaluate fit on resize for both directions"
+```
+
+---
+
+## Task 5: Manual verification
+
+No code changes — confirm the real behaviour in a browser, since the switch depends on DOM measurement that unit tests don't cover.
+
+**Files:** none.
+
+- [ ] **Step 1: Serve the app**
+
+Run: `npm start` (or `npm run watch` + your usual serve) and open the Experiences page.
+
+- [ ] **Step 2: Reproduce the short viewport**
+
+In DevTools, set a responsive viewport of **1280×720** (the effective CSS size of 1080p at Windows 150%). With a desktop width (>768px) and this short height, a content-rich card (e.g. "Technical Lead", ~15 bullets) should now render as a **flowing, natively-scrollable list** — no top/bottom clipping, all bullets reachable.
+
+- [ ] **Step 3: Confirm the round-trips**
+
+- Drag the viewport **taller** (e.g. 1280×1100): it should snap back to the card (magnetic) layout.
+- Drag it **shorter** again: back to flow.
+- Toggle **FR / EN** (changes card heights): the switch threshold should follow the content with no manual refresh.
+- Narrow the width below **768px**: still the flow/mobile layout, as before.
+
+- [ ] **Step 4: Confirm no regression on a tall desktop**
+
+At a normal tall desktop viewport (e.g. 1440×900 or larger), the magnetic card layout, wheel snapping, dots, and arrows behave exactly as before.
+
+---
+
+## Notes / out of scope
+
+- `attachMobileEvents()` remains defined but unused (the flow layout uses plain native scroll). Reviving its blur/scale focus effect is a separate follow-up on its own branch, per the spec — do **not** wire it here.

--- a/docs/superpowers/specs/2026-06-30-short-viewport-flow-fallback-design.md
+++ b/docs/superpowers/specs/2026-06-30-short-viewport-flow-fallback-design.md
@@ -1,0 +1,128 @@
+# Repli en mode flow sur écran court — Design
+
+**Date :** 2026-06-30
+**Branche :** `fix/150pc-low-res-display`
+**Composant touché :** `src/app/shared/magnetic-scroll/magnetic-scroll.component.{ts,html}`
+
+## Problème
+
+Sur un écran 1080p avec mise à l'échelle Windows à 150 %, le viewport CSS effectif
+tombe à ~1280×720 px (tout divisé par 1,5). C'est la **hauteur** qui pose problème :
+la zone utile passe d'environ 1028 px à environ 668 px.
+
+Le composant `magnetic-scroll` présente une carte à la fois, centrée dans une scène
+de hauteur `calc(100vh - var(--header-height))` avec `overflow: hidden`. Chaque carte
+est en `position: absolute` et son corps n'a aucun scroll interne
+(`.ms-card { overflow: hidden }`).
+
+Conséquence : une carte dont la hauteur intrinsèque dépasse celle de la scène est
+centrée puis **coupée en haut et en bas** par le `overflow: hidden`, sans aucun moyen
+pour l'utilisateur d'atteindre le contenu masqué. Les cartes riches (ex. « Technical
+Lead », ~15 puces) débordent dès que le viewport est court.
+
+## Décision retenue
+
+Réutiliser le rendu **flow** (liste à scroll natif) qui existe déjà dans le composant
+pour le mobile, et l'activer aussi quand l'écran est trop court pour le mode carte.
+Le mode flow n'a pas le problème de débordement : scroll natif, tout le contenu est
+atteignable.
+
+Le déclenchement se fait par **mesure dynamique** (pas par seuil fixe) : on bascule
+exactement quand la carte la plus haute ne tient pas dans la scène, et nulle part
+ailleurs. Cela s'adapte automatiquement au contenu et à la langue (FR/EN changent les
+hauteurs).
+
+## Architecture
+
+### Signal de décision
+
+Le composant a déjà un signal `isMobile` (alimenté par
+`matchMedia('(max-width: 768px)')`) qui pilote le `@if` du template entre rendu
+desktop (magnetic) et rendu mobile (flow).
+
+On ajoute un signal `tooTall`, et un computed qui devient la condition de rendu :
+
+```ts
+useFlow = computed(() => isMobile() || tooTall());
+```
+
+- Template : `@if (isMobile())` → `@if (useFlow())`.
+- Tous les tests `!isMobile()` qui conditionnent le setup desktop deviennent `!useFlow()`.
+
+### Calcul de `tooTall`
+
+Calculé à la fin de `scheduleMeasureAndRender`, juste après `measureAllHeights()`
+(déjà existant) :
+
+```
+availableH = stage.clientHeight - SAFETY      // SAFETY ≈ 24px de respiration
+tooTall    = max(this.heights) > availableH
+```
+
+On compare la carte **la plus haute** (pas chaque carte) : si une seule déborde, on
+bascule toute la section en flow pour une UX cohérente, plutôt que d'avoir un mélange
+de cartes OK et de cartes coupées.
+
+La dernière valeur de `max(this.heights)` est mise en cache (champ privé), car les
+hauteurs ne dépendent que de la **largeur** de la scène (wrapping du texte) et du
+contenu — jamais de sa hauteur.
+
+### Cycle de vie et bascule réactive
+
+Piège : pour mesurer les cartes desktop, le DOM desktop doit être monté, donc
+`useFlow` doit être `false` au moment de la mesure. Séquence :
+
+1. **Init** (largeur desktop) : on rend le desktop par défaut → le double-RAF mesure
+   → si trop haut, `tooTall` passe à `true` → le template bascule en flow. Le flip a
+   lieu pendant l'animation `ms-fade-in` (0,5 s), donc quasi invisible.
+2. **Resize hauteur seule** (cas Windows 150 % / fenêtre rétrécie) : la largeur ne
+   change pas → le cache `maxCardHeight` reste valide → on recompare au nouveau
+   `availableH` et on toggle `tooTall`. Pas de re-mesure nécessaire.
+3. **Resize largeur** : le cache de hauteurs peut être faux. On repasse optimiste en
+   desktop (`tooTall = false`), le double-RAF re-mesure et redécide. Un flash est
+   possible mais seulement sur changement de largeur (rare) et il s'auto-corrige.
+
+Le changement de couche active (desktop ⇄ flow) implique d'attacher/détacher les bons
+listeners. Aujourd'hui ils sont posés une seule fois dans `ngAfterViewInit`. On
+remplace ce câblage one-shot par une méthode idempotente **`syncLayout()`**, déclenchée
+par un `effect` sur `useFlow()` :
+
+- Gardée par un champ `wiredMode: 'desktop' | 'flow' | null`.
+- Quand la couche active change : détache les listeners de l'ancienne, attache ceux de
+  la nouvelle (events molette/touch desktop, ou scroll mobile), lance la mesure si on
+  (re)passe en desktop.
+- Idempotente : appelée plusieurs fois pour la même couche, ne refait rien.
+
+Ce choix réactif (vs un sens unique desktop→flow) est retenu pour la **cohérence** :
+le composant gère déjà le changement de largeur dans les deux sens via le listener
+`matchMedia`. Un repli hauteur en sens unique créerait une asymétrie (rétrécir/élargir
+la largeur fonctionne, mais rétrécir/élargir la hauteur coincerait l'utilisateur en
+flow).
+
+## Périmètre
+
+**Inclus :**
+- Bascule desktop → flow quand la carte la plus haute déborde la scène.
+- Retour propre desktop quand l'écran rallonge (réactif dans les deux sens).
+- Remplacement du câblage one-shot des listeners par `syncLayout()` idempotent.
+
+**Hors scope (follow-up sur branche dédiée) :**
+- `attachMobileEvents()` est **défini mais jamais appelé** : l'effet de blur/scale au
+  focus du rendu mobile est dormant aujourd'hui. Le mode flow fonctionne sans (scroll
+  natif simple, ce qui suffit à régler le débordement). Le réveiller changerait aussi
+  l'UX des vrais mobiles → décision et test séparés.
+
+## Tests
+
+- **Manuel (principal) :** DevTools en émulant 1280×720 ; vérifier qu'une carte riche
+  bascule en flow et que tout le contenu est atteignable ; toggle FR/EN (change les
+  hauteurs) ; resize hauteur et largeur pour valider les bascules dans les deux sens.
+- **Unitaire (si la base de tests le permet) :** extraire la règle de décision
+  (`max(heights) > availableH`) en fonction pure testable indépendamment du DOM.
+
+## Risques
+
+- `syncLayout()` est la seule modification structurelle (lifecycle des listeners) →
+  partie la plus à risque, gardée petite et idempotente.
+- Flash possible lors d'un resize **de largeur** pendant qu'on est en flow → toléré,
+  événement rare, auto-correction immédiate.

--- a/src/app/shared/magnetic-scroll/magnetic-scroll.component.html
+++ b/src/app/shared/magnetic-scroll/magnetic-scroll.component.html
@@ -1,6 +1,6 @@
 <!-- src/app/shared/magnetic-scroll/magnetic-scroll.component.html -->
 
-@if (isMobile()) {
+@if (useFlow()) {
 
   <!-- Mobile: normal vertical scroll, scroll-driven fade+blur+scale per card -->
   <div class="ms-mobile" #mobileScrollEl>

--- a/src/app/shared/magnetic-scroll/magnetic-scroll.component.spec.ts
+++ b/src/app/shared/magnetic-scroll/magnetic-scroll.component.spec.ts
@@ -1,0 +1,20 @@
+import { MagneticScrollComponent } from './magnetic-scroll.component';
+
+describe('MagneticScrollComponent.exceedsStage', () => {
+  it('returns false when the tallest card fits within the stage minus safety', () => {
+    expect(MagneticScrollComponent.exceedsStage(600, 720, 24)).toBe(false);
+  });
+
+  it('returns true when the tallest card exceeds the stage minus safety', () => {
+    expect(MagneticScrollComponent.exceedsStage(710, 720, 24)).toBe(true);
+  });
+
+  it('counts the safety margin as part of the budget', () => {
+    // 700 fits in 720 raw, but not in 720 - 24 = 696
+    expect(MagneticScrollComponent.exceedsStage(700, 720, 24)).toBe(true);
+  });
+
+  it('returns false for a non-positive stage height (not yet measured)', () => {
+    expect(MagneticScrollComponent.exceedsStage(700, 0, 24)).toBe(false);
+  });
+});

--- a/src/app/shared/magnetic-scroll/magnetic-scroll.component.ts
+++ b/src/app/shared/magnetic-scroll/magnetic-scroll.component.ts
@@ -119,6 +119,10 @@ export class MagneticScrollComponent
       };
       mq.addEventListener('change', onMqChange);
       this.cleanups.push(() => mq.removeEventListener('change', onMqChange));
+
+      const onResize = () => this.ngZone.run(() => this.onViewportResize());
+      window.addEventListener('resize', onResize);
+      this.cleanups.push(() => window.removeEventListener('resize', onResize));
     }
   }
 
@@ -221,6 +225,27 @@ export class MagneticScrollComponent
     const max = Math.max(0, this.flatItems.length - 1);
     this.progress = Math.max(0, Math.min(max, this.progress));
     this.render(this.progress);
+  }
+
+  // On resize: when cards are mounted, re-measure directly. When already in flow
+  // because of height, the chrome above the stage is fixed-px, so the stage
+  // height tracks innerHeight 1:1 — derive it from the cached measurement and
+  // re-decide without needing the (unmounted) desktop DOM.
+  private onViewportResize(): void {
+    if (this.isMobile()) return; // width transitions handled by matchMedia
+    if (this.wiredMode === 'desktop') {
+      this.measureAndDecide();
+    } else {
+      const stageH =
+        this.lastStageHeight + (window.innerHeight - this.lastInnerHeight);
+      this.tooTall.set(
+        MagneticScrollComponent.exceedsStage(
+          this.maxCardHeight,
+          stageH,
+          this.FIT_SAFETY,
+        ),
+      );
+    }
   }
 
   private teardownLayoutListeners(): void {

--- a/src/app/shared/magnetic-scroll/magnetic-scroll.component.ts
+++ b/src/app/shared/magnetic-scroll/magnetic-scroll.component.ts
@@ -236,6 +236,10 @@ export class MagneticScrollComponent
     if (this.wiredMode === 'desktop') {
       this.measureAndDecide();
     } else {
+      // Also covers wiredMode === null (before the first syncLayout measurement).
+      // Skip until the cache is populated, else a cold cache (all zeros) would
+      // spuriously flip back to the card layout.
+      if (this.lastInnerHeight === 0) return;
       const stageH =
         this.lastStageHeight + (window.innerHeight - this.lastInnerHeight);
       this.tooTall.set(

--- a/src/app/shared/magnetic-scroll/magnetic-scroll.component.ts
+++ b/src/app/shared/magnetic-scroll/magnetic-scroll.component.ts
@@ -30,6 +30,20 @@ import {
 export class MagneticScrollComponent
   implements AfterViewInit, OnChanges, OnDestroy
 {
+  /**
+   * True when the tallest card overflows the stage. `safety` reserves a little
+   * breathing room so cards are never flush against the stage edges.
+   * Returns false when the stage hasn't been measured yet (height <= 0).
+   */
+  static exceedsStage(
+    maxCardHeight: number,
+    stageHeight: number,
+    safety: number,
+  ): boolean {
+    if (stageHeight <= 0) return false;
+    return maxCardHeight > stageHeight - safety;
+  }
+
   @Input() sections: MagneticScrollSection[] = [];
 
   // Desktop refs

--- a/src/app/shared/magnetic-scroll/magnetic-scroll.component.ts
+++ b/src/app/shared/magnetic-scroll/magnetic-scroll.component.ts
@@ -87,24 +87,29 @@ export class MagneticScrollComponent
   private readonly SNAP_MS = 120;
   private readonly MAX_OVR = 0.15;
 
+  private readonly FIT_SAFETY = 24;
+
   private heights: number[] = [];
+  private maxCardHeight = 0;
+  private lastStageHeight = 0;
+  private lastInnerHeight = 0;
   private raf: number | null = null;
   private snapTimer: ReturnType<typeof setTimeout> | null = null;
   private wheelBusy = false;
   private touchStart: { y: number; progress: number } | null = null;
   private cleanups: (() => void)[] = [];
+  private layoutCleanups: (() => void)[] = [];
+  private wiredMode: 'desktop' | 'flow' | null = null;
 
   private ngZone = inject(NgZone);
   private viewReady = false;
 
+  // Re-wires listeners and (re)measures whenever the active layout changes.
+  private readonly layoutEffect = effect(() => this.syncLayout());
+
   ngAfterViewInit(): void {
     this.viewReady = true;
     this.flatten();
-
-    if (!this.isMobile()) {
-      this.attachEvents();
-      this.scheduleMeasureAndRender();
-    }
 
     if (typeof window !== 'undefined') {
       const mq = window.matchMedia('(max-width: 768px)');
@@ -120,14 +125,13 @@ export class MagneticScrollComponent
     if (!changes['sections']) return;
     this.flatten();
     if (!this.viewReady) return;
-    if (!this.isMobile()) {
-      this.scheduleMeasureAndRender();
-    }
+    this.syncLayout();
   }
 
   ngOnDestroy(): void {
     if (this.raf) cancelAnimationFrame(this.raf);
     if (this.snapTimer) clearTimeout(this.snapTimer);
+    this.teardownLayoutListeners();
     this.cleanups.forEach((fn) => fn());
   }
 
@@ -174,14 +178,53 @@ export class MagneticScrollComponent
     });
   }
 
-  private scheduleMeasureAndRender(): void {
+  // Wire the listeners for the active layout (idempotent) and, on desktop,
+  // (re)measure to decide whether the section still fits. Deferred a double-RAF
+  // so the @if has swapped the DOM and ViewChildren have updated.
+  private syncLayout(): void {
+    const target: 'desktop' | 'flow' = this.useFlow() ? 'flow' : 'desktop';
     this.scheduleDoubleRaf(() => {
-      if (!this.stageRef || this.flatItems.length === 0) return;
-      this.measureAllHeights();
-      const max = Math.max(0, this.flatItems.length - 1);
-      this.progress = Math.max(0, Math.min(max, this.progress));
-      this.render(this.progress);
+      if (!this.viewReady) return;
+
+      if (this.wiredMode !== target) {
+        this.teardownLayoutListeners();
+        this.wiredMode = target;
+        if (target === 'desktop') {
+          this.attachEvents();
+        }
+        // flow: native scroll only — parity with existing mobile behaviour.
+      }
+
+      if (target === 'desktop') {
+        this.measureAndDecide();
+      }
     });
+  }
+
+  // Measure the cards, cache the fit inputs, and flip `tooTall` accordingly.
+  private measureAndDecide(): void {
+    if (!this.stageRef || this.flatItems.length === 0) return;
+    this.measureAllHeights();
+    this.maxCardHeight = this.heights.length ? Math.max(...this.heights) : 0;
+    const stageH = this.stageRef.nativeElement.clientHeight;
+    this.lastStageHeight = stageH;
+    this.lastInnerHeight =
+      typeof window !== 'undefined' ? window.innerHeight : 0;
+    this.tooTall.set(
+      MagneticScrollComponent.exceedsStage(
+        this.maxCardHeight,
+        stageH,
+        this.FIT_SAFETY,
+      ),
+    );
+    const max = Math.max(0, this.flatItems.length - 1);
+    this.progress = Math.max(0, Math.min(max, this.progress));
+    this.render(this.progress);
+  }
+
+  private teardownLayoutListeners(): void {
+    this.layoutCleanups.forEach((fn) => fn());
+    this.layoutCleanups = [];
   }
 
   private render(p: number): void {
@@ -332,7 +375,7 @@ export class MagneticScrollComponent
       el.addEventListener('touchmove', onTouchMove, { passive: false });
       el.addEventListener('touchend', onTouchEnd, { passive: true });
 
-      this.cleanups.push(
+      this.layoutCleanups.push(
         () => el.removeEventListener('wheel', onWheel),
         () => el.removeEventListener('touchstart', onTouchStart),
         () => el.removeEventListener('touchmove', onTouchMove),

--- a/src/app/shared/magnetic-scroll/magnetic-scroll.component.ts
+++ b/src/app/shared/magnetic-scroll/magnetic-scroll.component.ts
@@ -90,6 +90,7 @@ export class MagneticScrollComponent
   private readonly FIT_SAFETY = 24;
 
   private heights: number[] = [];
+  // Cached fit inputs — consumed by the resize handler (onViewportResize).
   private maxCardHeight = 0;
   private lastStageHeight = 0;
   private lastInnerHeight = 0;
@@ -179,8 +180,8 @@ export class MagneticScrollComponent
   }
 
   // Wire the listeners for the active layout (idempotent) and, on desktop,
-  // (re)measure to decide whether the section still fits. Deferred a double-RAF
-  // so the @if has swapped the DOM and ViewChildren have updated.
+  // (re)measure to decide whether the section still fits. Deferred via a
+  // double-RAF so the @if has swapped the DOM and ViewChildren have updated.
   private syncLayout(): void {
     const target: 'desktop' | 'flow' = this.useFlow() ? 'flow' : 'desktop';
     this.scheduleDoubleRaf(() => {
@@ -223,6 +224,10 @@ export class MagneticScrollComponent
   }
 
   private teardownLayoutListeners(): void {
+    if (this.raf) {
+      cancelAnimationFrame(this.raf);
+      this.raf = null;
+    }
     this.layoutCleanups.forEach((fn) => fn());
     this.layoutCleanups = [];
   }

--- a/src/app/shared/magnetic-scroll/magnetic-scroll.component.ts
+++ b/src/app/shared/magnetic-scroll/magnetic-scroll.component.ts
@@ -3,6 +3,8 @@ import { CommonModule } from '@angular/common';
 import {
   AfterViewInit,
   Component,
+  computed,
+  effect,
   ElementRef,
   inject,
   Input,
@@ -71,6 +73,12 @@ export class MagneticScrollComponent
       ? window.matchMedia('(max-width: 768px)').matches
       : false,
   );
+
+  // True when the tallest card can't fit the stage → fall back to flow layout.
+  readonly tooTall = signal(false);
+
+  // The active layout: flow (native scroll) when narrow OR too tall, else cards.
+  readonly useFlow = computed(() => this.isMobile() || this.tooTall());
 
   private readonly PEEK = 150;
   private readonly TRAVEL = 160;

--- a/src/app/shared/magnetic-scroll/magnetic-scroll.component.ts
+++ b/src/app/shared/magnetic-scroll/magnetic-scroll.component.ts
@@ -134,9 +134,8 @@ export class MagneticScrollComponent
   }
 
   ngOnDestroy(): void {
-    if (this.raf) cancelAnimationFrame(this.raf);
     if (this.snapTimer) clearTimeout(this.snapTimer);
-    this.teardownLayoutListeners();
+    this.teardownLayoutListeners(); // also cancels any in-flight spring RAF
     this.cleanups.forEach((fn) => fn());
   }
 


### PR DESCRIPTION
This pull request addresses a usability issue with the `magnetic-scroll` component on short viewports (e.g., 1080p screens with Windows 150% scaling), where cards could be cut off with no way to scroll to hidden content. The solution is to automatically switch to a scrollable "flow" layout (previously used only on mobile) whenever the tallest card doesn't fit in the available space, and to return to the card layout when space allows. The implementation is dynamic, based on actual measurements rather than fixed breakpoints, and includes a refactor to manage event listeners reactively and safely. Unit tests are added for the fit logic.

**Short viewport fallback and layout management:**

* The component now dynamically switches to the flow (scrollable) layout when the tallest card doesn't fit in the stage, using a new `tooTall` signal and a computed `useFlow` signal to drive the template and logic. The layout can switch back and forth as the viewport changes, ensuring all content is always accessible. [[1]](diffhunk://#diff-11da00eb3f3e553435b8dbb3f29c4e792a813ff85becf2d7a40f496ec493e94cR77-R138) [[2]](diffhunk://#diff-c702763b1125cfcb8f790ceb42779e31f61099d801d1c0c61e5f5056187097c9L3-R3)
* The logic to determine if a card fits is extracted to a static method `exceedsStage`, which is unit tested for correctness and edge cases. [[1]](diffhunk://#diff-11da00eb3f3e553435b8dbb3f29c4e792a813ff85becf2d7a40f496ec493e94cR35-R48) [[2]](diffhunk://#diff-18fb2523c43deea76918154c45747dab5e62b0d440edc6ac7483a3a2b6cea2b5R1-R20)
* Event listener setup/teardown is refactored into a new idempotent `syncLayout()` method, triggered reactively whenever the layout mode changes, ensuring listeners are always attached to the correct elements and preventing leaks or duplicate bindings. [[1]](diffhunk://#diff-11da00eb3f3e553435b8dbb3f29c4e792a813ff85becf2d7a40f496ec493e94cR77-R138) [[2]](diffhunk://#diff-11da00eb3f3e553435b8dbb3f29c4e792a813ff85becf2d7a40f496ec493e94cL155-R260)

**Lifecycle and resize handling:**

* The resize handler now uses cached measurements to re-evaluate the layout mode efficiently, even when the DOM for cards is not present, preventing unnecessary DOM queries and flashes.
* Cleanups for layout-specific listeners are separated from global cleanups, and are properly managed during component destruction and layout switches. [[1]](diffhunk://#diff-11da00eb3f3e553435b8dbb3f29c4e792a813ff85becf2d7a40f496ec493e94cL155-R260) [[2]](diffhunk://#diff-11da00eb3f3e553435b8dbb3f29c4e792a813ff85becf2d7a40f496ec493e94cL313-R411)

**Documentation:**

* A comprehensive design doc is added, explaining the problem, decision, architecture, lifecycle, and risks for future maintainers.